### PR TITLE
Update jdCookie.js

### DIFF
--- a/jdCookie.js
+++ b/jdCookie.js
@@ -2,31 +2,33 @@
 此文件为Node.js专用。其他用户请忽略
  */
 //此处填写京东账号cookie。
-let CookieJDs = [];
+let CookieJDs = [
+  '',//账号一ck,例:pt_key=XXX;pt_pin=XXX;
+  '',//账号二ck,例:pt_key=XXX;pt_pin=XXX;如有更多,依次类推
+]
 // 判断环境变量里面是否有京东ck
 if (process.env.JD_COOKIE) {
   if (process.env.JD_COOKIE.indexOf('&') > -1) {
-    console.log(`您的cookie选择的是用&隔开\n`)
     CookieJDs = process.env.JD_COOKIE.split('&');
   } else if (process.env.JD_COOKIE.indexOf('\n') > -1) {
-    console.log(`您的cookie选择的是用换行隔开\n`)
     CookieJDs = process.env.JD_COOKIE.split('\n');
   } else {
     CookieJDs = [process.env.JD_COOKIE];
   }
 }
-if (JSON.stringify(process.env).indexOf('GITHUB') > -1) {
+if (JSON.stringify(process.env).indexOf('GITHUB')>-1) {
   console.log(`请勿使用github action运行此脚本,无论你是从你自己的私库还是其他哪里拉取的源代码，都会导致我被封号\n`);
   !(async () => {
     await require('./sendNotify').sendNotify('提醒', `请勿使用github action、滥用github资源会封我仓库以及账号`)
     await process.exit(0);
   })()
 }
-CookieJDs = [...new Set(CookieJDs.filter(item => item !== "" && item !== null && item !== undefined))]
-console.log(`\n====================共有${CookieJDs.length}个京东账号Cookie=========\n`);
-console.log(`==================脚本执行- 北京时间(UTC+8)：${new Date(new Date().getTime() + new Date().getTimezoneOffset() * 60 * 1000 + 8 * 60 * 60 * 1000).toLocaleString()}=====================\n`)
+CookieJDs = [...new Set(CookieJDs.filter(item => !!item))]
+console.log(`\n====================共${CookieJDs.length}个京东账号Cookie=========\n`);
+console.log(`==================脚本执行- 北京时间(UTC+8)：${new Date(new Date().getTime() + new Date().getTimezoneOffset()*60*1000 + 8*60*60*1000).toLocaleString()}=====================\n`)
+if (process.env.JD_DEBUG && process.env.JD_DEBUG === 'false') console.log = () => {};
 for (let i = 0; i < CookieJDs.length; i++) {
+  if (!CookieJDs[i].match(/pt_pin=(.+?);/) || !CookieJDs[i].match(/pt_key=(.+?);/)) console.log(`\n提示:京东cookie 【${CookieJDs[i]}】填写不规范,可能会影响部分脚本正常使用。正确格式为: pt_key=xxx;pt_pin=xxx;（分号;不可少）\n`);
   const index = (i + 1 === 1) ? '' : (i + 1);
   exports['CookieJD' + index] = CookieJDs[i].trim();
 }
-exports['CookieJDs'] = CookieJDs;


### PR DESCRIPTION
不是最新的，替换为最新的版本，解决使用这个jdCookie.js，会导致某些脚本错误中止，无法完成后续互相助力任务。